### PR TITLE
Made @mann-conomy/tf-parser a core dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mann-conomy/tf-particle-effects",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mann-conomy/tf-particle-effects",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@mann-conomy/tf-parser": "^1.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "@mann-conomy/tf-particle-effects",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@mann-conomy/tf-parser": "^1.1.1"
+      },
       "devDependencies": {
         "@eslint/js": "^9.6.0",
         "@jest/globals": "^29.7.0",
-        "@mann-conomy/tf-parser": "^1.1.1",
         "@mann-conomy/tsconfig": "^1.1.0",
         "@mann-conomy/typescript-eslint-config": "^1.0.0",
         "@types/jest": "^29.5.12",
@@ -25,6 +27,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.5.3",
         "typescript-eslint": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=8.17.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1377,8 +1382,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@mann-conomy/tf-parser/-/tf-parser-1.1.1.tgz",
       "integrity": "sha512-/T8dc358YzdR92NIPMViR3HyTQIsJqzDOSJfJ1Ajy+XKOky2/L/XMT/6xhB7JeSFsqyYx3GKIJt857uCNBHgTA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@eslint/js": "^9.6.0",
     "@jest/globals": "^29.7.0",
-    "@mann-conomy/tf-parser": "^1.1.1",
     "@mann-conomy/tsconfig": "^1.1.0",
     "@mann-conomy/typescript-eslint-config": "^1.0.0",
     "@types/jest": "^29.5.12",
@@ -53,6 +52,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
     "typescript-eslint": "^7.14.1"
+  },
+  "dependencies": {
+    "@mann-conomy/tf-parser": "^1.1.1"
   },
   "engines": {
     "node": ">=8.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mann-conomy/tf-particle-effects",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Node.js wrapper for Team Fortress 2's in-game particle effects.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
* Fixed an issue with the tf-parser types not included on a fresh install.